### PR TITLE
Fix cache reversal and small performance improvements.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,14 +4,6 @@ const nothing = () => Promise.resolve(null);
 const identity = x => x;
 const empty = x => x === null || x === void 0;
 
-function reverse(arr) {
-  let temp = [];
-  for (let i = arr.length - 1; i >= 0; i--) {
-    temp.push(arr[i]);
-  }
-  return temp;
-}
-
 function promiseUntil(predicate, funcs, args, index) {
   index = index || 0;
   const func = funcs[index];
@@ -39,7 +31,7 @@ class NLevelCache {
   constructor(options) {
     this.caches = options.caches || [];
     this.readers = this.caches.map(cache => cache.get);
-    this.writers = reverse(this.caches).map(cache => cache.set);
+    this.writers = [].concat(this.caches).reverse().map(cache => cache.set);
     this.compute = options.compute || nothing;
     this.keyForQuery = options.keyForQuery || identity;
     this.shouldCompute = options.shouldCompute || empty;

--- a/index.js
+++ b/index.js
@@ -4,6 +4,14 @@ const nothing = () => Promise.resolve(null);
 const identity = x => x;
 const empty = x => x === null || x === void 0;
 
+function reverse(arr) {
+  let temp = [];
+  for (let i = arr.length - 1; i >= 0; i--) {
+    temp.push(arr[i]);
+  }
+  return temp;
+}
+
 function promiseUntil(predicate, funcs, args, index) {
   index = index || 0;
   const func = funcs[index];
@@ -17,14 +25,12 @@ function promiseUntil(predicate, funcs, args, index) {
     });
 }
 
-function readCaches(caches, key, options) {
-  const readers = caches.map(cache => cache.get);
+function readCaches(readers, key, options) {
   const firstFound = x => x;
   return promiseUntil(firstFound, readers, [key, options]);
 }
 
-function writeCaches(caches, key, value, options) {
-  const writers = caches.reverse().map(cache => cache.set);
+function writeCaches(writers, key, value, options) {
   const never = () => false;
   return promiseUntil(never, writers, [key, value, options]);
 }
@@ -32,6 +38,8 @@ function writeCaches(caches, key, value, options) {
 class NLevelCache {
   constructor(options) {
     this.caches = options.caches || [];
+    this.readers = this.caches.map(cache => cache.get);
+    this.writers = reverse(this.caches).map(cache => cache.set);
     this.compute = options.compute || nothing;
     this.keyForQuery = options.keyForQuery || identity;
     this.shouldCompute = options.shouldCompute || empty;
@@ -39,7 +47,7 @@ class NLevelCache {
 
   get(query, options) {
     const key = this.keyForQuery(query);
-    return readCaches(this.caches, key, options).then(readValue => {
+    return readCaches(this.readers, key, options).then(readValue => {
       if (!this.shouldCompute(readValue)) return readValue;
       return this.set(query, options, key);
     });
@@ -49,7 +57,7 @@ class NLevelCache {
     return this.compute(query, options)
       .then(value => {
         key = key || this.keyForQuery(query);
-        return writeCaches(this.caches, key, value, options).then(() => value);
+        return writeCaches(this.writers, key, value, options).then(() => value);
       });
   }
 }


### PR DESCRIPTION
This PR introduces the following changes:
- When `caches.reverse()...` was called in `writeCaches`, the original `caches` array was being modified, so it would effect the next call to either `reachCaches` or `writeCaches`.
- There is no reason to recalculate writer and reader functions each time `readCaches` and `writeCaches` are called. Since this is very hot code for us, we should avoid this recalculation. 
